### PR TITLE
Modify delay instead of adding another value.

### DIFF
--- a/StopNotificationSpam.cfg
+++ b/StopNotificationSpam.cfg
@@ -1,6 +1,6 @@
 @DEPLOYEDSCIENCE
 {
-	ScienceTimeDelay = 21600
+	%ScienceTimeDelay = 21600
 	// Calculate science for timed experiments every x seconds.
 	// Change from the default value of 60 seconds to every 21600 seconds (once per Kerbin day)
 }


### PR DESCRIPTION
"ScienceTimeDelay = " will add another line resulting in the value being copied instead of being modified. % will add it if it's not there and modify it if it is.
Should make it work properly.